### PR TITLE
Match the API and behaviour of other compress packages.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015 Larz Conwell
+Copyright (c) 2016 Larz Conwell
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software
 and associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 bzip2
 ---
 
-[GoDoc](http://godoc.org/github.com/larzconwell/bzip2)
+[![GoDoc](https://godoc.org/github.com/larzconwell/bzip2?status.svg)](https://godoc.org/github.com/larzconwell/bzip2)
 
-Package bzip2 implements access to compress and decompress data in the bzip2 format.
+Package bzip2 implements reading and writing of bzip2 format compressed files.
 
-Currently this focuses on the compressor since [compress/bzip2](http://golang.org/pkg/compress/bzip2) doesn't include one.
+Currently this focuses on the writer since [compress/bzip2](http://golang.org/pkg/compress/bzip2) doesn't include one.
 
 Hopefully this will be eventually merged into the standard library without any changes on the users part.
 
 ### Notes
 
-References used to write the compressor since there's no specification:
+References used to write the writer since there's no specification:
 - https://en.wikipedia.org/wiki/Bzip2
 - https://bzip.org
 - https://code.google.com/p/jbzip2

--- a/doc.go
+++ b/doc.go
@@ -1,2 +1,2 @@
-// Package bzip2 implements compression and decompression of bzip2 data.
+// Package bzip2 implements reading and writing of bzip2 format compressed files.
 package bzip2

--- a/writer.go
+++ b/writer.go
@@ -1,7 +1,8 @@
 package bzip2
 
 import (
-	"errors"
+	"compress/flate"
+	"fmt"
 	"io"
 
 	"github.com/larzconwell/bzip2/internal/bits"
@@ -16,20 +17,22 @@ const (
 	baseBlockSize = 100000
 )
 
-var (
-	// ErrWriteAfterClose occurs when a Write
-	// occurs after a Writer is closed.
-	ErrWriteAfterClose = errors.New("bzip2: write after close")
+// These constants are copied from the flate package, so that
+// code does not also have to import "compress/flate".
+const (
+	BestSpeed       = flate.BestSpeed
+	BestCompression = flate.BestCompression
 )
 
 // Writer is an io.WriteCloser. Writes to a Writer are
-// compressed and written to the underlying io.Writer.
+// compressed and written to an underlying io.Writer.
 type Writer struct {
 	bw          *bits.Writer
 	block       *block
 	crc         uint32
 	wroteHeader bool
 	closed      bool
+	err         error
 }
 
 // NewWriter returns a new Writer. Writes to the returned
@@ -48,68 +51,72 @@ func NewWriter(w io.Writer) *Writer {
 // NewWriterLevel is like NewWriter but specifies the
 // compression level.
 //
-// The level must be between 1 and 9, any other values are
-// set to the closest valid level.
-func NewWriterLevel(w io.Writer, level int) *Writer {
-	if level < 1 {
-		level = 1
-	} else if level > 9 {
-		level = 9
+// The levels range from 1 (BestSpeed) to 9 (BestCompression);
+// higher levels typically run slower but compress more.
+//
+// If level is in the range [1, 9] then the error returned will
+// be nil. Otherwise the error returned will be non-nil.
+func NewWriterLevel(w io.Writer, level int) (*Writer, error) {
+	if level < BestSpeed || level > BestCompression {
+		return nil, fmt.Errorf("bzip2: invalid compression level: %d", level)
 	}
 
 	return &Writer{
 		bw:    bits.NewWriter(w),
 		block: newBlock(level * baseBlockSize),
-	}
+	}, nil
 }
 
 // Write writes a compressed form of p to the underlying
 // io.Writer. The compressed bytes are not necessarily
 // flushed until the Writer is closed.
-func (b *Writer) Write(p []byte) (int, error) {
-	if b.closed {
-		return 0, ErrWriteAfterClose
+func (w *Writer) Write(p []byte) (int, error) {
+	if w.err != nil {
+		return 0, w.err
 	}
+	var n int
 
-	if !b.wroteHeader {
-		err := b.writeHeader()
-		if err != nil {
-			return 0, err
+	// Handle writing the file header.
+	if !w.wroteHeader {
+		w.err = w.writeHeader()
+		if w.err != nil {
+			return 0, w.err
 		}
 
-		b.wroteHeader = true
+		w.wroteHeader = true
 	}
 
-	return b.write(p)
+	n, w.err = w.write(p)
+	return n, w.err
 }
 
 // writeHeader writes the file header.
-func (b *Writer) writeHeader() error {
-	b.bw.WriteBits(16, fileMagic)
-	b.bw.WriteBits(8, 'h')
-	b.bw.WriteBits(8, uint64('0'+b.block.size/baseBlockSize))
+func (w *Writer) writeHeader() error {
+	w.bw.WriteBits(16, fileMagic)
+	w.bw.WriteBits(8, 'h')
+	w.bw.WriteBits(8, uint64('0'+w.block.size/baseBlockSize))
 
-	return b.bw.Err()
+	return w.bw.Err()
 }
 
 // write handles the writing of block data and writing
 // completed blocks to the underlying io.Writer.
-func (b *Writer) write(p []byte) (int, error) {
-	n, err := b.block.Write(p)
+func (w *Writer) write(p []byte) (int, error) {
+	n, err := w.block.Write(p)
 	if err != errBlockSizeReached {
 		return n, err
 	}
 
 	// Write the complete block, left over
 	// bytes being written to a new block.
-	err = b.writeBlock()
+	err = w.writeBlock()
 	if err != nil {
 		return n, err
 	}
 
 	if n != len(p) {
 		var nn int
-		nn, err = b.write(p[n:])
+		nn, err = w.write(p[n:])
 		n += nn
 	}
 
@@ -118,60 +125,89 @@ func (b *Writer) write(p []byte) (int, error) {
 
 // writeBlock writes the current block to the
 // underlying io.Writer and updates the files crc.
-func (b *Writer) writeBlock() error {
-	err := b.block.WriteBlock(b.bw)
+func (w *Writer) writeBlock() error {
+	err := w.block.WriteBlock(w.bw)
 	if err != nil {
 		return err
 	}
 
-	b.crc = ((b.crc << 1) | (b.crc >> 31)) ^ b.block.crc
-	b.block = newBlock(b.block.size)
+	w.crc = ((w.crc << 1) | (w.crc >> 31)) ^ w.block.crc
+	w.block = newBlock(w.block.size)
 	return nil
 }
 
 // Flush flushes any pending compressed data
-// to the underlying io.Writer.
-func (b *Writer) Flush() error {
-	if b.closed || b.block.Len() == 0 {
+// to the underlying writer.
+func (w *Writer) Flush() error {
+	if w.err != nil {
+		return w.err
+	}
+	if w.closed || w.block.Len() == 0 {
 		return nil
 	}
 
-	return b.writeBlock()
+	// Handle writing the file header.
+	if !w.wroteHeader {
+		w.err = w.writeHeader()
+		if w.err != nil {
+			return w.err
+		}
+
+		w.wroteHeader = true
+	}
+
+	w.err = w.writeBlock()
+	return w.err
 }
 
-// Reset discards the Writers state and makes it equivalent to the result
-// of its original state from NewWriter or NewWriterLevel, but writing to
-// w instead. This permits reusing a Writer rather than allocating a new one.
-func (b *Writer) Reset(w io.Writer) {
-	b.bw = bits.NewWriter(w)
-	b.block = newBlock(b.block.size)
-	b.crc = 0
-	b.wroteHeader = false
-	b.closed = false
+// Reset discards the state of Writer and makes it equivalent
+// to the result of NewWriter or NewWriterLevel, but writing
+// to dst instead.
+func (w *Writer) Reset(dst io.Writer) {
+	w.bw = bits.NewWriter(dst)
+	w.block = newBlock(w.block.size)
+	w.crc = 0
+	w.wroteHeader = false
+	w.closed = false
+	w.err = nil
 }
 
 // Close closes the Writer, flushing any unwritten data to the
 // underlying io.Writer, but does not close the underlying io.Writer.
-func (b *Writer) Close() error {
-	if b.closed {
+func (w *Writer) Close() error {
+	if w.err != nil {
+		return w.err
+	}
+	if w.closed {
 		return nil
 	}
-	b.closed = true
+	w.closed = true
+
+	// Handle writing the file header.
+	if !w.wroteHeader {
+		w.err = w.writeHeader()
+		if w.err != nil {
+			return w.err
+		}
+
+		w.wroteHeader = true
+	}
 
 	// Flush the current block.
-	if b.block.Len() != 0 {
-		err := b.writeBlock()
-		if err != nil {
-			return err
+	if w.block.Len() != 0 {
+		w.err = w.writeBlock()
+		if w.err != nil {
+			return w.err
 		}
 	}
 
-	b.bw.WriteBits(48, finalMagic)
-	b.bw.WriteBits(32, uint64(b.crc))
-	bufferedBits := b.bw.Buffered()
+	w.bw.WriteBits(48, finalMagic)
+	w.bw.WriteBits(32, uint64(w.crc))
+	bufferedBits := w.bw.Buffered()
 	if bufferedBits != 0 {
-		b.bw.WriteBits(8-bufferedBits, 0)
+		w.bw.WriteBits(8-bufferedBits, 0)
 	}
 
-	return b.bw.Err()
+	w.err = w.bw.Err()
+	return w.err
 }


### PR DESCRIPTION
Remove explicit WriteAfterClose error, no other compress package uses it
and the underlying writer would presumably be closed soon after so that
would propagate up.

For NewWriterLevel return error instead of changing the given level,
also use the flate packages constants for the best levels.

Also for every operation if an error has already occured don't permit
other actions to continue.
